### PR TITLE
feat: Create Entities get endpoint

### DIFF
--- a/backend/src/BlogDoFt.SbusEmulatorViewer.Api/Controllers/EntitiesController.cs
+++ b/backend/src/BlogDoFt.SbusEmulatorViewer.Api/Controllers/EntitiesController.cs
@@ -1,0 +1,29 @@
+using BlogDoFt.SbusEmulatorViewer.Api.Models;
+using Microsoft.AspNetCore.Mvc;
+
+namespace BlogDoFt.SbusEmulatorViewer.Api.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    public class EntitiesController : ControllerBase
+    {
+        private readonly EntitiesParser _entities;
+
+        public EntitiesController(EntitiesParser entities)
+        {
+            _entities = entities;
+        }
+
+        [HttpGet]
+        public async Task<IActionResult> ListEntitiesAsync(CancellationToken cancellation = default)
+        {
+            var topics = await _entities.GetTopicsAsync(cancellation);
+            if (topics.Any())
+            {
+                return Ok(topics);
+            }
+
+            return NotFound();
+        }
+    }
+}

--- a/backend/src/BlogDoFt.SbusEmulatorViewer.Api/Models/EntitiesParser.cs
+++ b/backend/src/BlogDoFt.SbusEmulatorViewer.Api/Models/EntitiesParser.cs
@@ -1,0 +1,86 @@
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Options;
+using System.Text.Json;
+
+namespace BlogDoFt.SbusEmulatorViewer.Api.Models;
+
+public class EntitiesParser
+{
+    private readonly string _configPath;
+    private readonly IFileProvider _fileProvider;
+
+    private readonly Lazy<Task<IReadOnlyList<Topic>>> _lazyTopics;
+
+    public EntitiesParser(
+        IOptions<ServiceBusSettings> sbusSettings,
+        IWebHostEnvironment env)
+    {
+        _configPath = sbusSettings.Value.EmulatorConfigFile;
+        _fileProvider = env.ContentRootFileProvider;
+        _lazyTopics = new Lazy<Task<IReadOnlyList<Topic>>>(LoadTopicsAsync);
+    }
+
+    public Task<IReadOnlyList<Topic>> GetTopicsAsync(CancellationToken cancellationToken = default)
+        => _lazyTopics.Value;
+
+
+    private async Task<IReadOnlyList<Topic>> LoadTopicsAsync()
+    {
+        if (!File.Exists(_configPath))
+        {
+            throw new FileNotFoundException(
+                "Arquivo de configuração não encontrado.", _configPath);
+        }
+
+        using var stream = File.OpenRead(_configPath);
+        var root = await JsonSerializer
+            .DeserializeAsync<RootConfig>(stream, new JsonSerializerOptions
+            {
+                PropertyNameCaseInsensitive = true
+            });
+
+        var namespaces = root?.UserConfig?.Namespaces ?? [];
+
+        var topics = namespaces
+            .Where(ns => ns.Topics is not null)
+            .SelectMany(ns => ns.Topics!)
+            .Select(t => new Topic(
+                TopicName: t.Name!,
+                Subscriptions: t.Subscriptions?
+                    .Select(s => s.Name!)
+                    .ToArray()
+                ?? []
+            ))
+            .ToList()
+            .AsReadOnly();
+
+        return topics;
+    }
+
+
+    private sealed class SubscriptionConfig
+    {
+        public string? Name { get; set; }
+    }
+
+    private sealed class TopicConfig
+    {
+        public string? Name { get; set; }
+        public SubscriptionConfig[]? Subscriptions { get; set; }
+    }
+
+    private sealed class NamespaceConfig
+    {
+        public string? Name { get; set; }
+        public TopicConfig[]? Topics { get; set; }
+    }
+    private sealed class UserConfig
+    {
+        public NamespaceConfig[]? Namespaces { get; set; }
+    }
+
+    private sealed class RootConfig
+    {
+        public UserConfig? UserConfig { get; set; }
+    }
+}

--- a/backend/src/BlogDoFt.SbusEmulatorViewer.Api/Models/ServiceBusSettings.cs
+++ b/backend/src/BlogDoFt.SbusEmulatorViewer.Api/Models/ServiceBusSettings.cs
@@ -2,7 +2,6 @@ namespace BlogDoFt.SbusEmulatorViewer.Api.Models;
 
 public class ServiceBusSettings
 {
-    public string ConnectionString { get; set; } = default!;
-    public string QueueName { get; set; } = default!;
+    public required string ConnectionString { get; init; }
+    public required string EmulatorConfigFile { get; init; }
 }
-

--- a/backend/src/BlogDoFt.SbusEmulatorViewer.Api/Models/Topic.cs
+++ b/backend/src/BlogDoFt.SbusEmulatorViewer.Api/Models/Topic.cs
@@ -1,0 +1,3 @@
+namespace BlogDoFt.SbusEmulatorViewer.Api.Models;
+
+public record Topic(string TopicName, IReadOnlyList<string> Subscriptions);

--- a/backend/src/BlogDoFt.SbusEmulatorViewer.Api/Program.cs
+++ b/backend/src/BlogDoFt.SbusEmulatorViewer.Api/Program.cs
@@ -28,6 +28,7 @@ builder.Services
         var settings = sp.GetRequiredService<IOptions<ServiceBusSettings>>().Value;
         return new ServiceBusAdministrationClient(settings.ConnectionString);
     })
+    .AddSingleton<EntitiesParser>()
     .AddScoped<IServiceBusService, ServiceBusService>();
 
 var app = builder.Build();

--- a/backend/src/BlogDoFt.SbusEmulatorViewer.Api/appsettings.json
+++ b/backend/src/BlogDoFt.SbusEmulatorViewer.Api/appsettings.json
@@ -7,6 +7,7 @@
   },
   "AllowedHosts": "*",
   "ServiceBus": {
-    "ConnectionString": "Endpoint=sb://localhost;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=SAS_KEY_VALUE;UseDevelopmentEmulator=true;"
+    "ConnectionString": "Endpoint=sb://localhost;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=SAS_KEY_VALUE;UseDevelopmentEmulator=true;",
+    "EmulatorConfigFile": "/home/ftathiago/src/blogdoft/sbus-emulator-viewer/eng/docker/sbus-emulator/config.json"
   }
 }


### PR DESCRIPTION
Based on Sbus Emulator file config (provided by path), this endpoint is able to return a list of registered topics.

This is needed as the SbusEmulator does not support Administration connection.